### PR TITLE
Fix broken pickle advancement

### DIFF
--- a/src/main/resources/data/culturaldelights/advancements/pickle.json
+++ b/src/main/resources/data/culturaldelights/advancements/pickle.json
@@ -17,9 +17,11 @@
       "conditions": {
         "items": [
           {
-            "item": "culturaldelights:pickle"
+            "items": [
+              "culturaldelights:pickle"
+            ]
           }
-        ]
+        
       }
     }
   },


### PR DESCRIPTION
This advancement currently triggers on any item entering the inventory. It is currently using an outdated format.