### PR TITLE
Fix koi nigiri recipe by using a tag

### DIFF
--- a/src/main/resources/data/culturaldelights/recipes/mat_rolling/koi_nigiri.json
+++ b/src/main/resources/data/culturaldelights/recipes/mat_rolling/koi_nigiri.json
@@ -8,13 +8,13 @@
       "item": "farmersdelight:cooked_rice"
     },
     {
-      "item": "environmental:koi"
+      "tag": "forge:raw_fishes/koi"
     },
     {
-      "item": "environmental:koi"
+      "tag": "forge:raw_fishes/koi"
     },
     {
-      "item": "environmental:koi"
+      "tag": "forge:raw_fishes/koi"
     }
   ],
   "output": {

--- a/src/main/resources/data/forge/tags/items/raw_fishes.json
+++ b/src/main/resources/data/forge/tags/items/raw_fishes.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#forge:raw_fishes/koi"
+  ]
+}

--- a/src/main/resources/data/forge/tags/items/raw_fishes/koi.json
+++ b/src/main/resources/data/forge/tags/items/raw_fishes/koi.json
@@ -1,0 +1,13 @@
+{
+  "replace": false,
+  "values": [
+    {
+      "id": "environmental:koi",
+      "required": false
+    },
+    {
+      "id": "crittersandcompanions:koi_fish",
+      "required": false
+    }
+  ]
+}


### PR DESCRIPTION
Farmer's Delight uses "forge:raw_fishes/NAME" tags to distinguish raw fishes and use them in ingredients. This PR introduces the tag into the koi nigiri recipe, and adds support for the koi fish added by https://www.curseforge.com/minecraft/mc-mods/critters-and-companions